### PR TITLE
feat: [P0] Loading skeletons — feed + post pages

### DIFF
--- a/src/app/app/feed/loading.tsx
+++ b/src/app/app/feed/loading.tsx
@@ -1,0 +1,158 @@
+export default function FeedLoading() {
+  return (
+    <div className="space-y-0 -mx-8 -mt-8 animate-pulse">
+      {/* ── TOP BAR skeleton ── */}
+      <div
+        className="sticky top-0 z-30 w-full h-14 px-8 flex justify-between items-center"
+        style={{
+          background: "rgba(20,27,43,0.8)",
+          backdropFilter: "blur(20px)",
+          borderBottom: "1px solid rgba(46,53,69,0.15)",
+        }}
+      >
+        <div className="flex items-center gap-8">
+          {/* Logo placeholder */}
+          <div className="h-5 w-36 bg-muted rounded" />
+          {/* Nav tab placeholders */}
+          <div className="hidden md:flex gap-6">
+            {[80, 72, 68].map((w, i) => (
+              <div key={i} className="h-3.5 rounded bg-muted" style={{ width: w }} />
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-4">
+          {/* Search input placeholder */}
+          <div className="h-8 w-64 bg-muted rounded-sm" />
+          {/* Icon placeholders */}
+          <div className="h-8 w-8 rounded-full bg-muted" />
+          <div className="h-8 w-8 rounded-full bg-muted" />
+          {/* Avatar placeholder */}
+          <div className="w-8 h-8 rounded-full bg-muted" />
+        </div>
+      </div>
+
+      {/* ── SEARCH SUMMARY skeleton ── */}
+      <div className="px-8 py-6">
+        <div className="h-4 w-48 bg-muted rounded" />
+      </div>
+
+      {/* ── MAIN CONTENT skeleton ── */}
+      <div className="px-8 pb-12 flex gap-8">
+        {/* Left: feed table skeleton */}
+        <section className="w-2/3">
+          <div className="bg-surface-container-low rounded-xl overflow-hidden shadow-lg">
+            <table className="w-full text-left border-collapse">
+              {/* Header row */}
+              <thead>
+                <tr className="bg-surface-container-highest/50">
+                  {[160, 80, 56, 60, 88, 72].map((w, i) => (
+                    <th key={i} className="px-6 py-4">
+                      <div className="h-3 rounded bg-muted" style={{ width: w }} />
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              {/* 8 placeholder rows */}
+              <tbody className="divide-y divide-outline-variant/15">
+                {Array.from({ length: 8 }).map((_, rowIdx) => (
+                  <tr key={rowIdx} className="hover:bg-surface-container-high/40">
+                    {/* Post column: thumbnail + title */}
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <div className="w-12 h-12 rounded bg-muted shrink-0" />
+                        <div className="space-y-2">
+                          <div className="h-3.5 w-40 bg-muted rounded" />
+                          <div className="h-3 w-28 bg-muted rounded" />
+                        </div>
+                      </div>
+                    </td>
+                    {/* Creator */}
+                    <td className="px-6 py-4">
+                      <div className="h-3.5 w-20 bg-muted rounded" />
+                    </td>
+                    {/* Signals */}
+                    <td className="px-6 py-4">
+                      <div className="h-3.5 w-8 bg-muted rounded" />
+                    </td>
+                    {/* Urgency badge */}
+                    <td className="px-6 py-4">
+                      <div className="h-5 w-14 bg-muted rounded-full" />
+                    </td>
+                    {/* Posted */}
+                    <td className="px-6 py-4">
+                      <div className="h-3.5 w-20 bg-muted rounded" />
+                    </td>
+                    {/* Platform */}
+                    <td className="px-6 py-4">
+                      <div className="h-3.5 w-16 bg-muted rounded" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Right: detail panel skeleton */}
+        <section className="w-1/3">
+          <div
+            className="sticky top-20 bg-surface-container-low rounded-xl p-6 shadow-2xl space-y-8"
+            style={{ borderLeft: "1px solid rgba(67,70,84,0.1)" }}
+          >
+            {/* Panel header */}
+            <div className="flex justify-between items-start">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-6 bg-muted" />
+                  <div className="h-6 w-40 bg-muted rounded" />
+                </div>
+                <div className="h-3 w-32 bg-muted rounded" />
+              </div>
+              <div className="w-6 h-6 bg-muted rounded-sm" />
+            </div>
+
+            {/* Sparkline placeholder */}
+            <div className="space-y-3">
+              <div className="flex justify-between items-end">
+                <div className="h-3 w-28 bg-muted rounded" />
+                <div className="h-4 w-12 bg-muted rounded" />
+              </div>
+              <div className="h-24 w-full bg-muted rounded-sm" />
+            </div>
+
+            {/* Breakdown chips */}
+            <div className="space-y-4">
+              <div className="h-3 w-28 bg-muted rounded" />
+              <div className="flex flex-wrap gap-2">
+                {[88, 100, 128, 96].map((w, i) => (
+                  <div key={i} className="h-7 bg-muted rounded-sm" style={{ width: w }} />
+                ))}
+              </div>
+            </div>
+
+            {/* CTAs */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="h-10 bg-muted rounded-sm" />
+              <div className="h-10 bg-muted rounded-sm" />
+            </div>
+
+            {/* In the news */}
+            <div className="pt-8 space-y-6" style={{ borderTop: "1px solid rgba(67,70,84,0.15)" }}>
+              <div className="h-3 w-24 bg-muted rounded" />
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="flex gap-4">
+                  <div className="w-16 h-16 shrink-0 rounded bg-muted" />
+                  <div className="flex flex-col justify-between flex-1 space-y-2">
+                    <div className="h-3 w-full bg-muted rounded" />
+                    <div className="h-3 w-4/5 bg-muted rounded" />
+                    <div className="h-2.5 w-24 bg-muted rounded" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/feed/page.tsx
+++ b/src/app/app/feed/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import FeedPostsTable from "./FeedPostsTable.tsx";
+import FeedPostsTable from "./FeedPostsTable";
 
 type FeedPost = {
   id: string;

--- a/src/app/app/posts/[id]/loading.tsx
+++ b/src/app/app/posts/[id]/loading.tsx
@@ -1,0 +1,160 @@
+export default function PostLoading() {
+  return (
+    <div className="grid grid-cols-12 gap-8 max-w-[1400px] mx-auto animate-pulse">
+      {/* ── LEFT COLUMN ── */}
+      <section className="col-span-12 lg:col-span-7 space-y-8">
+        {/* Video / thumbnail placeholder */}
+        <div className="relative rounded-xl overflow-hidden bg-surface-container-low shadow-2xl">
+          <div className="w-full aspect-video bg-muted" />
+        </div>
+
+        {/* Creator attribution row */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            {/* Avatar */}
+            <div className="w-8 h-8 rounded-full bg-muted shrink-0" />
+            <div className="space-y-2">
+              {/* Username */}
+              <div className="h-4 w-28 bg-muted rounded" />
+              {/* Followers */}
+              <div className="h-3 w-20 bg-muted rounded" />
+            </div>
+          </div>
+          {/* View on platform link */}
+          <div className="h-4 w-32 bg-muted rounded" />
+        </div>
+
+        {/* Caption block */}
+        <div className="bg-surface-container-low p-6 rounded-xl space-y-4">
+          <div className="h-3.5 w-full bg-muted rounded" />
+          <div className="h-3.5 w-11/12 bg-muted rounded" />
+          <div className="h-3.5 w-4/5 bg-muted rounded" />
+          {/* Hashtag chips */}
+          <div className="flex flex-wrap gap-2 pt-2">
+            {[72, 88, 64, 96, 80].map((w, i) => (
+              <div key={i} className="h-5 bg-muted rounded" style={{ width: w }} />
+            ))}
+          </div>
+        </div>
+
+        {/* 4-stat grid */}
+        <div className="grid grid-cols-4 gap-4">
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="bg-surface-container-low p-4 rounded-xl flex flex-col gap-2 border-b border-primary/5"
+            >
+              <div className="h-2.5 w-14 bg-muted rounded" />
+              <div className="h-6 w-16 bg-muted rounded" />
+            </div>
+          ))}
+        </div>
+
+        {/* Transcript + Tower's Read */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Transcript */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="h-4 w-24 bg-muted rounded" />
+              <div className="h-4 w-24 bg-muted rounded" />
+            </div>
+            <div className="h-48 bg-surface-container-low rounded-xl p-4 space-y-3">
+              {[100, 90, 95, 88, 92].map((pct, i) => (
+                <div
+                  key={i}
+                  className="h-3 bg-muted rounded"
+                  style={{ width: `${pct}%` }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Tower's Read */}
+          <div className="space-y-4">
+            <div className="h-4 w-28 bg-muted rounded" />
+            <div className="h-48 bg-primary/10 rounded-xl border border-primary/20 p-5 space-y-3 flex flex-col justify-center">
+              {[92, 100, 88, 76].map((pct, i) => (
+                <div
+                  key={i}
+                  className="h-3 bg-muted rounded"
+                  style={{ width: `${pct}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── RIGHT COLUMN ── */}
+      <section className="col-span-12 lg:col-span-5 space-y-8">
+        {/* Urgency gauge placeholder */}
+        <div className="bg-surface-container-low p-8 rounded-xl flex flex-col items-center justify-center text-center space-y-4">
+          {/* SVG ring placeholder */}
+          <div className="w-40 h-40 rounded-full bg-muted" />
+          {/* Urgency label */}
+          <div className="h-5 w-36 bg-muted rounded" />
+          {/* Sub-label */}
+          <div className="h-3 w-48 bg-muted rounded" />
+          {/* Creator score bar */}
+          <div
+            className="mt-6 w-full pt-6 flex justify-between items-center px-4"
+            style={{ borderTop: "1px solid rgba(180,197,255,0.1)" }}
+          >
+            <div className="h-3 w-24 bg-muted rounded" />
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-24 bg-muted rounded-full" />
+              <div className="h-4 w-8 bg-muted rounded" />
+            </div>
+          </div>
+        </div>
+
+        {/* Demand signals panel placeholder */}
+        <div
+          className="bg-surface-container-low rounded-xl overflow-hidden"
+          style={{ border: "1px solid rgba(180,197,255,0.05)" }}
+        >
+          {/* Panel header */}
+          <div className="p-6 bg-surface-container-high/50 flex justify-between items-center">
+            <div className="space-y-2">
+              <div className="h-4 w-32 bg-muted rounded" />
+              <div className="h-3 w-24 bg-muted rounded" />
+            </div>
+            <div className="w-6 h-6 bg-muted rounded" />
+          </div>
+
+          {/* Signal cards */}
+          <div className="p-4 space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="bg-surface-container-highest/40 p-4 rounded-lg border-l-2 border-muted"
+              >
+                {/* Top row: time + badges */}
+                <div className="flex justify-between items-start mb-3">
+                  <div className="h-3 w-16 bg-muted rounded" />
+                  <div className="flex gap-2">
+                    <div className="h-4 w-16 bg-muted rounded-sm" />
+                    <div className="h-4 w-20 bg-muted rounded-sm" />
+                  </div>
+                </div>
+                {/* Signal text lines */}
+                <div className="space-y-2 mb-4">
+                  <div className="h-3 w-full bg-muted rounded" />
+                  <div className="h-3 w-10/12 bg-muted rounded" />
+                </div>
+                {/* Claim button placeholder */}
+                <div className="h-8 w-full bg-muted rounded-sm" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer metadata */}
+        <div className="space-y-2">
+          <div className="h-3 w-48 bg-muted rounded" />
+          <div className="h-3 w-40 bg-muted rounded" />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/app/posts/[id]/page.tsx
+++ b/src/app/app/posts/[id]/page.tsx
@@ -146,14 +146,15 @@ export default async function PostPage({
   }
 
   const post = postResult.data as Post;
-  const surface = (surfaceResult.data as (Surface & { posts?: { id: string }[] }) | null)
+  const surfaceRaw = surfaceResult.data as (Surface & { posts?: { id: string }[] }) | null;
+  const surface: Surface | null = surfaceRaw
     ? ({
-        username: surfaceResult.data.username,
-        full_name: surfaceResult.data.full_name,
-        followers: surfaceResult.data.followers,
-        is_verified: surfaceResult.data.is_verified,
-        avatar_url: surfaceResult.data.avatar_url,
-        incumbency_score: surfaceResult.data.incumbency_score,
+        username: surfaceRaw.username,
+        full_name: surfaceRaw.full_name,
+        followers: surfaceRaw.followers,
+        is_verified: surfaceRaw.is_verified,
+        avatar_url: surfaceRaw.avatar_url,
+        incumbency_score: surfaceRaw.incumbency_score,
       } as Surface)
     : null;
   const signals: Signal[] = signalsResult.data ?? [];


### PR DESCRIPTION
Closes #3

## Changes
- Added `src/app/app/feed/loading.tsx` — pulsing skeleton matching table layout (header + 8 rows)
- Added `src/app/app/posts/[id]/loading.tsx` — pulsing skeleton matching 2-column layout
- Fixed pre-existing type error in `feed/page.tsx` (`.tsx` extension in import path)
- Fixed pre-existing type error in `posts/[id]/page.tsx` (`surfaceResult.data` null narrowing)

## Acceptance Criteria
- [x] src/app/app/feed/loading.tsx — skeleton matching table layout (header + 8 placeholder rows)
- [x] src/app/app/posts/[id]/loading.tsx — skeleton matching 2-column layout
- [x] Skeletons use pulsing animation consistent with design system
- [x] No blank flash visible when navigating between pages