### PR TITLE
feat: enforce RLS across public tables and server role client

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,17 +1,27 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import "server-only";
 
 /**
  * Creates a Supabase client for use in Server Components and Route Handlers.
- * Uses the anon key — RLS policies on your tables control row-level access.
+ * Uses the service role key in server-only contexts so app data can be fetched
+ * securely while public/anon API access remains blocked by RLS.
  * Call this inside an async Server Component; do not cache the instance.
  */
 export function createClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    throw new Error(
+      "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required."
+    );
+  }
+
   const cookieStore = cookies();
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseServiceRoleKey,
     {
       cookies: {
         getAll() {

--- a/supabase/migrations/20260422134800_enable_rls_on_all_public_tables.sql
+++ b/supabase/migrations/20260422134800_enable_rls_on_all_public_tables.sql
@@ -1,0 +1,34 @@
+-- Enable RLS on every table in the public schema.
+-- This is dynamic so it covers the current full table set (28 tables)
+-- and any future tables created before this migration is re-run in lower envs.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select schemaname, tablename
+    from pg_tables
+    where schemaname = 'public'
+  loop
+    execute format('alter table %I.%I enable row level security', r.schemaname, r.tablename);
+    execute format('alter table %I.%I force row level security', r.schemaname, r.tablename);
+  end loop;
+end
+$$;
+
+-- Explicitly ensure anon/authenticated cannot query app data directly.
+-- Server-side app access is provided by SUPABASE_SERVICE_ROLE_KEY only.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select schemaname, tablename
+    from pg_tables
+    where schemaname = 'public'
+  loop
+    execute format('revoke all on table %I.%I from anon', r.schemaname, r.tablename);
+    execute format('revoke all on table %I.%I from authenticated', r.schemaname, r.tablename);
+  end loop;
+end
+$$;


### PR DESCRIPTION
## Summary
- add a migration to enable RLS across all current public tables and revoke anon/authenticated select access by default
- update server Supabase client to require `SUPABASE_SERVICE_ROLE_KEY` in server-only code
- keep app server components functional via service role while preventing direct anon data reads

## Test plan
- [ ] Run migrations against Supabase DB
- [ ] Verify anon key calls to posts/signals/surfaces return no rows
- [ ] Verify app pages still load data from server components
- [ ] Run `npm run build`

Closes #1