### PR TITLE
feat: add auth login/signup and protected app middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,62 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            request.cookies.set(name, value)
+          );
+
+          response = NextResponse.next({
+            request: {
+              headers: request.headers,
+            },
+          });
+
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const pathname = request.nextUrl.pathname;
+  const isAuthPage = pathname === "/app/login" || pathname === "/app/signup";
+
+  if (!user && !isAuthPage) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/app/login";
+    return NextResponse.redirect(url);
+  }
+
+  if (user && pathname === "/app/login") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/app/feed";
+    return NextResponse.redirect(url);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/app/:path*"],
+};

--- a/src/app/app/account/page.tsx
+++ b/src/app/app/account/page.tsx
@@ -1,0 +1,10 @@
+export default function AccountPage() {
+  return (
+    <section className="space-y-2">
+      <h1 className="text-2xl font-headline font-bold tracking-tight">Account</h1>
+      <p className="text-on-surface-variant">
+        Account settings are coming soon.
+      </p>
+    </section>
+  );
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 
 const navItems = [
@@ -12,6 +14,43 @@ const navItems = [
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  const isAuthPage = pathname === "/app/login" || pathname === "/app/signup";
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    async function loadUser() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      setUserEmail(user?.email ?? null);
+    }
+
+    loadUser();
+  }, []);
+
+  const userInitial = useMemo(() => {
+    if (!userEmail) return "?";
+    return userEmail.charAt(0).toUpperCase();
+  }, [userEmail]);
+
+  async function handleLogout() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/app/login");
+    router.refresh();
+  }
+
+  if (isAuthPage) {
+    return (
+      <div className="min-h-screen bg-background text-on-background">
+        {children}
+      </div>
+    );
+  }
 
   return (
     <div className="flex bg-background min-h-screen">
@@ -67,14 +106,18 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             New Inquiry
           </button>
           <div className="flex flex-col gap-1 pt-4" style={{ borderTop: "1px solid rgba(67,70,84,0.2)" }}>
-            <Link href="#" className="text-on-surface-variant hover:text-on-background py-2 px-2 flex items-center gap-3 text-sm font-headline">
+            <Link href="/app/account" className="text-on-surface-variant hover:text-on-background py-2 px-2 flex items-center gap-3 text-sm font-headline">
               <span className="material-symbols-outlined text-lg">account_circle</span>
               Account
             </Link>
-            <Link href="#" className="text-on-surface-variant hover:text-on-background py-2 px-2 flex items-center gap-3 text-sm font-headline">
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="text-on-surface-variant hover:text-on-background py-2 px-2 flex items-center gap-3 text-sm font-headline text-left"
+            >
               <span className="material-symbols-outlined text-lg">logout</span>
               Logout
-            </Link>
+            </button>
           </div>
         </div>
       </aside>
@@ -94,7 +137,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <span className="material-symbols-outlined">settings</span>
             </button>
             <div className="w-8 h-8 rounded-full bg-surface-container-highest flex items-center justify-center ml-2">
-              <span className="material-symbols-outlined text-on-surface text-sm">person</span>
+              <span className="text-on-surface text-sm font-bold">{userInitial}</span>
             </div>
           </div>
         </header>

--- a/src/app/app/login/actions.ts
+++ b/src/app/app/login/actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function login(formData: FormData) {
+  const email = String(formData.get("email") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+
+  if (!email || !password) {
+    redirect("/app/login?error=Email%20and%20password%20are%20required");
+  }
+
+  const supabase = createClient();
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    redirect(`/app/login?error=${encodeURIComponent(error.message)}`);
+  }
+
+  redirect("/app/feed");
+}

--- a/src/app/app/login/page.tsx
+++ b/src/app/app/login/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { login } from "./actions";
+
+type LoginPageProps = {
+  searchParams?: {
+    error?: string;
+    message?: string;
+  };
+};
+
+export default function LoginPage({ searchParams }: LoginPageProps) {
+  return (
+    <main className="min-h-screen bg-background text-on-background flex items-center justify-center p-8">
+      <div className="w-full max-w-md rounded-xl bg-surface-container-low p-8 space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-headline font-bold tracking-tight">Log In</h1>
+          <p className="text-sm text-on-surface-variant">
+            Access your Sovereign Intelligence workspace.
+          </p>
+        </div>
+
+        {searchParams?.error ? (
+          <p className="rounded-md bg-error/20 text-error px-3 py-2 text-sm">
+            {searchParams.error}
+          </p>
+        ) : null}
+
+        {searchParams?.message ? (
+          <p className="rounded-md bg-primary/15 text-primary px-3 py-2 text-sm">
+            {searchParams.message}
+          </p>
+        ) : null}
+
+        <form action={login} className="space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor="email" className="text-sm text-on-surface-variant">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              className="w-full rounded-md border border-outline bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="password" className="text-sm text-on-surface-variant">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              className="w-full rounded-md border border-outline bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90"
+          >
+            Log In
+          </button>
+        </form>
+
+        <p className="text-sm text-on-surface-variant">
+          Need an account?{" "}
+          <Link href="/app/signup" className="text-primary hover:underline">
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/app/signup/actions.ts
+++ b/src/app/app/signup/actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function signup(formData: FormData) {
+  const email = String(formData.get("email") ?? "").trim();
+  const password = String(formData.get("password") ?? "");
+
+  if (!email || !password) {
+    redirect("/app/signup?error=Email%20and%20password%20are%20required");
+  }
+
+  const supabase = createClient();
+  const { error } = await supabase.auth.signUp({ email, password });
+
+  if (error) {
+    redirect(`/app/signup?error=${encodeURIComponent(error.message)}`);
+  }
+
+  redirect("/app/login?message=Signup%20successful.%20Please%20log%20in.");
+}

--- a/src/app/app/signup/page.tsx
+++ b/src/app/app/signup/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { signup } from "./actions";
+
+type SignupPageProps = {
+  searchParams?: {
+    error?: string;
+  };
+};
+
+export default function SignupPage({ searchParams }: SignupPageProps) {
+  return (
+    <main className="min-h-screen bg-background text-on-background flex items-center justify-center p-8">
+      <div className="w-full max-w-md rounded-xl bg-surface-container-low p-8 space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-headline font-bold tracking-tight">Sign Up</h1>
+          <p className="text-sm text-on-surface-variant">
+            Create your account to start using Sovereign Intelligence.
+          </p>
+        </div>
+
+        {searchParams?.error ? (
+          <p className="rounded-md bg-error/20 text-error px-3 py-2 text-sm">
+            {searchParams.error}
+          </p>
+        ) : null}
+
+        <form action={signup} className="space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor="email" className="text-sm text-on-surface-variant">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              className="w-full rounded-md border border-outline bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="password" className="text-sm text-on-surface-variant">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              minLength={6}
+              className="w-full rounded-md border border-outline bg-background px-3 py-2 text-sm"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90"
+          >
+            Create Account
+          </button>
+        </form>
+
+        <p className="text-sm text-on-surface-variant">
+          Already have an account?{" "}
+          <Link href="/app/login" className="text-primary hover:underline">
+            Log in
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}


### PR DESCRIPTION
## Summary
- add `/app/login` and `/app/signup` with Supabase auth server actions
- protect `/app/*` routes with root middleware and redirect unauthenticated users to login
- add logout flow, topbar email initial rendering, and `/app/account` stub

## Test plan
- [ ] Visit `/app/feed` while logged out and verify redirect to `/app/login`
- [ ] Sign up and log in; verify redirect to `/app/feed`
- [ ] Verify authenticated access to app routes
- [ ] Log out and verify redirect to `/app/login`
- [ ] Run `npm run build`

Closes #2