### PR TITLE
feat: seed topics table with real immigration topics for search

### DIFF
--- a/supabase/migrations/20260423000000_seed_topics_for_search.sql
+++ b/supabase/migrations/20260423000000_seed_topics_for_search.sql
@@ -1,0 +1,7 @@
+-- Seed initial topics so the Discover search has real data beyond canada-immigration
+INSERT INTO topics (slug, title, query, status)
+VALUES
+  ('atlantic-canada-immigration', 'Atlantic Canada Immigration', 'atlantic canada immigration', 'active'),
+  ('canada-study-permit',         'Canada Study Permit',         'canada study permit',         'active'),
+  ('south-africa-immigration',    'South Africa Immigration',    'south africa immigration',    'active')
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds 3 new active topics to the `topics` table: Atlantic Canada Immigration, Canada Study Permit, South Africa Immigration
- The Discover search typeahead reads from `topics` dynamically — previously only `canada-immigration` existed, making search broken for all other inputs
- Migration uses `ON CONFLICT (slug) DO NOTHING` so it's safe to run multiple times

## What this unblocks

Discover search now shows all 4 topics in typeahead and navigates to the correct `/app/intelligence/[slug]` page for each (dynamic routing already landed in #27).

## Test plan
- [ ] Visit `/app/discover`, focus the search box — 4 topic chips should appear
- [ ] Type "study" — filters to Canada Study Permit only
- [ ] Select it — navigates to `/app/intelligence/canada-study-permit`
- [ ] Repeat for South Africa Immigration and Atlantic Canada Immigration