### PR TITLE
fix: align trigger tasks to current schema columns

### DIFF
--- a/src/trigger/tasks/classify-and-create-surfaces.ts
+++ b/src/trigger/tasks/classify-and-create-surfaces.ts
@@ -23,38 +23,65 @@ export type ClassifyResult = {
 type Classification = {
   is_relevant: boolean;
   confidence: number;
+  space_slug: string | null;
 };
 
 function guardClassification(payload: Record<string, unknown>): Classification {
   const confidenceRaw = payload.confidence;
   const confidence =
     typeof confidenceRaw === "number" && Number.isFinite(confidenceRaw) ? confidenceRaw : 0;
-  return { is_relevant: payload.is_relevant === true, confidence };
+  const spaceSlug =
+    typeof payload.space_slug === "string" && payload.space_slug.trim().length > 0
+      ? payload.space_slug.trim()
+      : null;
+  return { is_relevant: payload.is_relevant === true, confidence, space_slug: spaceSlug };
 }
 
 export const classifyAndCreateSurfacesTask = task({
   id: "classify-and-create-surfaces",
   run: async (payload: ClassifyPayload): Promise<ClassifyResult> => {
     const supabase = getSupabaseAdmin();
-    const relevantProfiles: Profile[] = [];
+    const relevantProfiles: Array<{ profile: Profile; spaceSlug: string | null }> = [];
 
     for (const profile of payload.profiles) {
       const result = await openAiJson(
         "Classify profile relevance to the topic. Return strict JSON only.",
-        `Topic slug: ${payload.topicSlug}\nQuery: ${payload.query}\nUsername: ${profile.username}\nFull name: ${profile.fullName}\nBiography: ${profile.biography}\nReturn {"is_relevant": boolean, "confidence": number}.`,
+        `Topic slug: ${payload.topicSlug}
+Query: ${payload.query}
+Username: ${profile.username}
+Full name: ${profile.fullName}
+Biography: ${profile.biography}
+Return {"is_relevant": boolean, "confidence": number, "space_slug": string|null}.`,
         guardClassification,
       );
-      if (result.is_relevant) relevantProfiles.push(profile);
+      if (result.is_relevant) {
+        relevantProfiles.push({ profile, spaceSlug: result.space_slug });
+      }
     }
 
     if (relevantProfiles.length === 0) return { surfaceIds: [] };
 
-    const upsertRows = relevantProfiles.map((profile) => ({
+    const spaceIdBySlug = new Map<string, string>();
+    const uniqueSpaceSlugs = [...new Set(relevantProfiles.map((item) => item.spaceSlug).filter(Boolean))];
+    for (const slug of uniqueSpaceSlugs) {
+      const { data: spaceRow, error: spaceError } = await supabase
+        .from("spaces")
+        .select("id")
+        .eq("slug", slug)
+        .maybeSingle();
+      if (spaceError) throw spaceError;
+      if (spaceRow?.id) {
+        spaceIdBySlug.set(slug, spaceRow.id as string);
+      }
+    }
+
+    const upsertRows = relevantProfiles.map(({ profile, spaceSlug }) => ({
       username: profile.username,
       full_name: profile.fullName,
       biography: profile.biography,
       followers: profile.followersCount,
       avatar_url: profile.profilePicUrl ?? null,
+      space_id: spaceSlug ? spaceIdBySlug.get(spaceSlug) ?? null : null,
       status: "pending",
     }));
 

--- a/src/trigger/tasks/generate-summary.ts
+++ b/src/trigger/tasks/generate-summary.ts
@@ -35,7 +35,7 @@ export const generateSummaryTask = task({
 
     const { data: signals, error: signalsError } = await supabase
       .from("signals")
-      .select("comment_text, urgency_score, intent_label")
+      .select("text, urgency_score, intent_label")
       .eq("post_id", payload.postId)
       .order("urgency_score", { ascending: false })
       .limit(5);


### PR DESCRIPTION
## Summary
- align Trigger task schema usage with live DB columns: `surfaces.biography`, `surfaces.followers`, and `signals.text`
- update `classify-and-create-surfaces` to resolve existing `spaces` by `slug` and set `surfaces.space_id`
- do not create/seed spaces in task code and do not touch `enrich-topic.ts` triggerAndWait wiring

## Test plan
- [ ] Run Trigger task dry runs for classify and summary tasks
- [ ] Verify relevant profiles update `surfaces.space_id` when slug exists in `spaces`
- [ ] Verify summary task reads `signals.text` and updates `posts.ai_summary`
