### PR TITLE
fix: resolve trigger integration build blockers on main

### DIFF
--- a/src/trigger/tasks/classify-and-create-surfaces.ts
+++ b/src/trigger/tasks/classify-and-create-surfaces.ts
@@ -62,7 +62,10 @@ Return {"is_relevant": boolean, "confidence": number, "space_slug": string|null}
     if (relevantProfiles.length === 0) return { surfaceIds: [] };
 
     const spaceIdBySlug = new Map<string, string>();
-    const uniqueSpaceSlugs = [...new Set(relevantProfiles.map((item) => item.spaceSlug).filter(Boolean))];
+    const uniqueSpaceSlugs = relevantProfiles
+      .map((item) => item.spaceSlug)
+      .filter((slug): slug is string => typeof slug === "string" && slug.length > 0)
+      .filter((slug, index, arr) => arr.indexOf(slug) === index);
     for (const slug of uniqueSpaceSlugs) {
       const { data: spaceRow, error: spaceError } = await supabase
         .from("spaces")

--- a/src/trigger/tasks/enrich-topic.ts
+++ b/src/trigger/tasks/enrich-topic.ts
@@ -109,6 +109,8 @@ async function incrementCompletedChildren(parentJobId: string): Promise<void> {
 // TODO(@trigger.dev #13): wrap in `export const enrichTopicTask = task({ ... })`
 export async function enrichTopic(payload: EnrichTopicPayload): Promise<void> {
   const { jobId, topicId, slug, query } = payload;
+  void slug;
+  void query;
   const supabase = createServiceClient();
 
   try {
@@ -156,6 +158,7 @@ export async function enrichTopic(payload: EnrichTopicPayload): Promise<void> {
 
     for (const surface of surfaces ?? []) {
       const childJobId = await createChildJob(jobId, "scrape-posts", surface.id);
+      void childJobId;
 
       // TODO(@trigger.dev #13): replace with:
       // const { postIds: ids } = await tasks.triggerAndWait("scrape-posts", {

--- a/src/trigger/tasks/find-profiles.ts
+++ b/src/trigger/tasks/find-profiles.ts
@@ -53,17 +53,7 @@ export const findProfilesTask = task({
           profilePicUrl,
         };
       })
-      .filter(
-        (
-          profile,
-        ): profile is {
-          username: string;
-          fullName: string;
-          biography: string;
-          followersCount: number;
-          profilePicUrl?: string;
-        } => Boolean(profile),
-      );
+      .filter((profile): profile is NonNullable<typeof profile> => profile !== null);
 
     return { profiles };
   },

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -3,4 +3,5 @@ import { defineConfig } from "@trigger.dev/sdk/v3";
 export default defineConfig({
   project: "<TRIGGER_PROJECT_REF>",
   dirs: ["./src/trigger/tasks"],
+  maxDuration: 3600,
 });


### PR DESCRIPTION
## Summary
- fix post-merge build blockers in trigger files introduced by orchestration integration
- resolve unused variable lint errors in `enrich-topic.ts` while keeping TODO scaffolding and triggerAndWait calls commented
- fix TypeScript issues in trigger tasks and add required `maxDuration` in `trigger.config.ts`

## Root cause
`next build` failed on `main` due a chain of trigger-related compile/lint issues:
- unused vars in `enrich-topic.ts`
- TS narrowing issue in `find-profiles.ts`
- TS iteration/type issue in `classify-and-create-surfaces.ts`
- missing required `maxDuration` in Trigger config typing

## Test plan
- [x] Run `npm run build`
- [x] Verify no trigger task compile/lint blockers remain
- [ ] Verify Vercel deployment on this PR turns green