### PR TITLE
fix: wire trigger call + add missing topic_id FK on surfaces

### DIFF
--- a/src/app/api/topics/enrich/route.ts
+++ b/src/app/api/topics/enrich/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { tasks } from "@trigger.dev/sdk/v3";
 import { createServiceClient, createClient } from "@/lib/supabase/server";
 
 function slugify(text: string): string {
@@ -88,8 +89,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Failed to create job" }, { status: 500 });
   }
 
-  // TODO(@trigger.dev): Fire enrichment task once #13 (Trigger.dev migration) is complete.
-  // await tasks.trigger("enrich-topic", { jobId: job.id, topicId: topic.id, slug, query });
+  await tasks.trigger("enrich-topic", { jobId: job.id, topicId: topic.id, slug, query });
 
   return NextResponse.json({ jobId: job.id, topicSlug: slug });
 }

--- a/src/trigger/tasks/classify-and-create-surfaces.ts
+++ b/src/trigger/tasks/classify-and-create-surfaces.ts
@@ -85,6 +85,7 @@ Return {"is_relevant": boolean, "confidence": number, "space_slug": string|null}
       followers: profile.followersCount,
       avatar_url: profile.profilePicUrl ?? null,
       space_id: spaceSlug ? spaceIdBySlug.get(spaceSlug) ?? null : null,
+      topic_id: payload.topicId,
       status: "pending",
     }));
 

--- a/supabase/migrations/20260424000005_add_topic_id_to_surfaces.sql
+++ b/supabase/migrations/20260424000005_add_topic_id_to_surfaces.sql
@@ -1,0 +1,5 @@
+-- recompute-scores queries surfaces WHERE topic_id = topicId
+-- classify-and-create-surfaces needs somewhere to write the topic FK
+ALTER TABLE surfaces ADD COLUMN IF NOT EXISTS topic_id uuid REFERENCES topics(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS surfaces_topic_id_idx ON surfaces(topic_id) WHERE topic_id IS NOT NULL;


### PR DESCRIPTION
- /api/topics/enrich: uncomment tasks.trigger("enrich-topic") — pipeline now fires on every enrich request (was silently no-op since PR #33)
- classify-and-create-surfaces: write topic_id to surfaces rows so recompute-scores can query surfaces WHERE topic_id = topicId
- migration: add surfaces.topic_id uuid FK → topics(id) + index