### PR TITLE
fix: trigger cutover + child job observability

### DIFF
--- a/src/app/api/topics/enrich/route.ts
+++ b/src/app/api/topics/enrich/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { tasks } from "@trigger.dev/sdk/v3";
 import { createServiceClient, createClient } from "@/lib/supabase/server";
 
 function slugify(text: string): string {
@@ -88,8 +89,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Failed to create job" }, { status: 500 });
   }
 
-  // TODO(@trigger.dev): Fire enrichment task once #13 (Trigger.dev migration) is complete.
-  // await tasks.trigger("enrich-topic", { jobId: job.id, topicId: topic.id, slug, query });
+  await tasks.trigger("enrich-topic", { jobId: job.id, topicId: topic.id, slug, query });
 
   return NextResponse.json({ jobId: job.id, topicSlug: slug });
 }

--- a/src/trigger/tasks/analyze-signals.ts
+++ b/src/trigger/tasks/analyze-signals.ts
@@ -1,5 +1,5 @@
 import { task } from "@trigger.dev/sdk/v3";
-import { asNumber, asString, getSupabaseAdmin, openAiJson } from "./helpers";
+import { asNumber, asString, closeJob, getSupabaseAdmin, openAiJson } from "./helpers";
 
 type PostRow = { id: string; surface_id: string; caption: string | null; latest_comments: unknown; surfaces: { username: string | null } | null };
 
@@ -13,6 +13,7 @@ type SignalClassification = {
 
 export type AnalyzeSignalsPayload = {
   postId: string;
+  jobId?: string;
 };
 
 export type AnalyzeSignalsResult = {
@@ -57,6 +58,7 @@ function extractComments(
 export const analyzeSignalsTask = task({
   id: "analyze-signals",
   run: async (payload: AnalyzeSignalsPayload): Promise<AnalyzeSignalsResult> => {
+    try {
     const supabase = getSupabaseAdmin();
     const { data, error } = await supabase
       .from("posts")
@@ -120,6 +122,12 @@ export const analyzeSignalsTask = task({
       .eq("id", post.id);
     if (postUpdateError) throw postUpdateError;
 
-    return { signalCount: inserts.length, highUrgencyCount };
+    const result = { signalCount: inserts.length, highUrgencyCount };
+    if (payload.jobId) await closeJob(payload.jobId, "completed");
+    return result;
+    } catch (err) {
+      if (payload.jobId) await closeJob(payload.jobId, "failed", (err as Error).message);
+      throw err;
+    }
   },
 });

--- a/src/trigger/tasks/classify-and-create-surfaces.ts
+++ b/src/trigger/tasks/classify-and-create-surfaces.ts
@@ -85,6 +85,7 @@ Return {"is_relevant": boolean, "confidence": number, "space_slug": string|null}
       followers: profile.followersCount,
       avatar_url: profile.profilePicUrl ?? null,
       space_id: spaceSlug ? spaceIdBySlug.get(spaceSlug) ?? null : null,
+      topic_id: payload.topicId,
       status: "pending",
     }));
 

--- a/src/trigger/tasks/enrich-topic.ts
+++ b/src/trigger/tasks/enrich-topic.ts
@@ -174,13 +174,14 @@ export async function enrichTopic(payload: EnrichTopicPayload): Promise<void> {
     const postIds: string[] = [];
 
     for (const surface of surfaces ?? []) {
-      await createChildJob(jobId, "scrape-posts", surface.id);
+      const scrapeJobId = await createChildJob(jobId, "scrape-posts", surface.id);
       if (!surface.username) {
         throw new Error(`Surface ${surface.id} is missing username`);
       }
       const { postIds: ids } = getTaskOutput<ScrapePostsResult>(await tasks.triggerAndWait("scrape-posts", {
         surfaceId: surface.id,
         username: surface.username,
+        jobId: scrapeJobId,
       }), "scrape-posts");
       postIds.push(...ids);
 
@@ -196,12 +197,12 @@ export async function enrichTopic(payload: EnrichTopicPayload): Promise<void> {
     await setStage(jobId, "scoring_signals", { total_children: postIds.length, completed_children: 0 });
 
     for (const postId of postIds) {
-      await createChildJob(jobId, "analyze-signals", postId);
-      await createChildJob(jobId, "generate-summary", postId);
+      const analyzeJobId = await createChildJob(jobId, "analyze-signals", postId);
+      const summaryJobId = await createChildJob(jobId, "generate-summary", postId);
 
       const [analyzeResult, summaryResult] = await Promise.all([
-        tasks.triggerAndWait("analyze-signals", { postId }),
-        tasks.triggerAndWait("generate-summary", { postId }),
+        tasks.triggerAndWait("analyze-signals", { postId, jobId: analyzeJobId }),
+        tasks.triggerAndWait("generate-summary", { postId, jobId: summaryJobId }),
       ]);
       getTaskOutput(analyzeResult, "analyze-signals");
       getTaskOutput(summaryResult, "generate-summary");
@@ -212,7 +213,7 @@ export async function enrichTopic(payload: EnrichTopicPayload): Promise<void> {
     // ── Step 5: Recompute topic-level scores ─────────────────────────────────
     await setStage(jobId, "recomputing");
 
-    getTaskOutput(await tasks.triggerAndWait("recompute-scores", { topicId }), "recompute-scores");
+    getTaskOutput(await tasks.triggerAndWait("recompute-scores", { topicId, jobId }), "recompute-scores");
 
     // ── Step 6: Mark complete ─────────────────────────────────────────────────
     await setStage(jobId, "ready");

--- a/src/trigger/tasks/generate-summary.ts
+++ b/src/trigger/tasks/generate-summary.ts
@@ -1,8 +1,9 @@
 import { task } from "@trigger.dev/sdk/v3";
-import { asString, getSupabaseAdmin, openAiJson } from "./helpers";
+import { asString, closeJob, getSupabaseAdmin, openAiJson } from "./helpers";
 
 export type GenerateSummaryPayload = {
   postId: string;
+  jobId?: string;
 };
 
 export type GenerateSummaryResult = {
@@ -25,6 +26,7 @@ function summaryGuard(payload: Record<string, unknown>): SummaryPayload {
 export const generateSummaryTask = task({
   id: "generate-summary",
   run: async (payload: GenerateSummaryPayload): Promise<GenerateSummaryResult> => {
+    try {
     const supabase = getSupabaseAdmin();
     const { data: post, error: postError } = await supabase
       .from("posts")
@@ -55,6 +57,12 @@ export const generateSummaryTask = task({
       .eq("id", payload.postId);
     if (updateError) throw updateError;
 
-    return { title: summary.title, summary: summary.read };
+    const result = { title: summary.title, summary: summary.read };
+    if (payload.jobId) await closeJob(payload.jobId, "completed");
+    return result;
+    } catch (err) {
+      if (payload.jobId) await closeJob(payload.jobId, "failed", (err as Error).message);
+      throw err;
+    }
   },
 });

--- a/src/trigger/tasks/helpers.ts
+++ b/src/trigger/tasks/helpers.ts
@@ -126,3 +126,28 @@ export function asString(value: unknown): string | null {
 export function asNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
+
+/**
+ * Closes a child jobs row with a terminal status.
+ * Call on success AND in the catch block of every task so orphaned
+ * "running" rows never accumulate.
+ */
+export async function closeJob(
+  jobId: string,
+  status: "completed" | "failed",
+  error?: string,
+): Promise<void> {
+  try {
+    const supabase = getSupabaseAdmin();
+    await supabase
+      .from("jobs")
+      .update({
+        status,
+        completed_at: new Date().toISOString(),
+        ...(error ? { error } : {}),
+      })
+      .eq("id", jobId);
+  } catch {
+    // Best-effort — never let a DB write failure mask the original error
+  }
+}

--- a/src/trigger/tasks/recompute-scores.ts
+++ b/src/trigger/tasks/recompute-scores.ts
@@ -1,8 +1,9 @@
 import { task } from "@trigger.dev/sdk/v3";
-import { asNumber, getSupabaseAdmin } from "./helpers";
+import { asNumber, closeJob, getSupabaseAdmin } from "./helpers";
 
 export type RecomputePayload = {
   topicId: string;
+  jobId?: string;
 };
 
 export type RecomputeResult = {
@@ -13,6 +14,7 @@ export type RecomputeResult = {
 export const recomputeScoresTask = task({
   id: "recompute-scores",
   run: async (payload: RecomputePayload): Promise<RecomputeResult> => {
+    try {
     const supabase = getSupabaseAdmin();
     const { data: surfaces, error: surfacesError } = await supabase
       .from("surfaces")
@@ -61,6 +63,12 @@ export const recomputeScoresTask = task({
       .eq("id", payload.topicId);
     if (topicUpdateError) throw topicUpdateError;
 
-    return { topicUrgencyScore, surfacesUpdated };
+    const result = { topicUrgencyScore, surfacesUpdated };
+    if (payload.jobId) await closeJob(payload.jobId, "completed");
+    return result;
+    } catch (err) {
+      if (payload.jobId) await closeJob(payload.jobId, "failed", (err as Error).message);
+      throw err;
+    }
   },
 });

--- a/src/trigger/tasks/scrape-posts.ts
+++ b/src/trigger/tasks/scrape-posts.ts
@@ -5,6 +5,7 @@ import {
   apifyWaitForRunCompletion,
   asNumber,
   asString,
+  closeJob,
   getSupabaseAdmin,
 } from "./helpers";
 
@@ -12,6 +13,7 @@ export type ScrapePostsPayload = {
   surfaceId: string;
   username: string;
   maxPosts?: number;
+  jobId?: string;
 };
 
 export type ScrapePostsResult = {
@@ -21,6 +23,7 @@ export type ScrapePostsResult = {
 export const scrapePostsTask = task({
   id: "scrape-posts",
   run: async (payload: ScrapePostsPayload): Promise<ScrapePostsResult> => {
+    try {
     const supabase = getSupabaseAdmin();
     const run = await apifyRunActor("apify~instagram-post-scraper", {
       directUrls: [`https://www.instagram.com/${payload.username}/`],
@@ -72,6 +75,12 @@ export const scrapePostsTask = task({
       .eq("id", payload.surfaceId);
     if (surfaceError) throw surfaceError;
 
-    return { postIds: (postData ?? []).map((row) => (row as { id: string }).id) };
+    const result = { postIds: (postData ?? []).map((row) => (row as { id: string }).id) };
+    if (payload.jobId) await closeJob(payload.jobId, "completed");
+    return result;
+    } catch (err) {
+      if (payload.jobId) await closeJob(payload.jobId, "failed", (err as Error).message);
+      throw err;
+    }
   },
 });

--- a/supabase/migrations/20260424000005_add_topic_id_to_surfaces.sql
+++ b/supabase/migrations/20260424000005_add_topic_id_to_surfaces.sql
@@ -1,0 +1,5 @@
+-- recompute-scores queries surfaces WHERE topic_id = topicId
+-- classify-and-create-surfaces needs somewhere to write the topic FK
+ALTER TABLE surfaces ADD COLUMN IF NOT EXISTS topic_id uuid REFERENCES topics(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS surfaces_topic_id_idx ON surfaces(topic_id) WHERE topic_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Wire the trigger call** — `/api/topics/enrich` was creating job rows but never actually firing the `enrich-topic` task (TODO comment left uncommented since PR #33)
- **Add `surfaces.topic_id` FK** — `recompute-scores` queries `surfaces WHERE topic_id = topicId` but the column didn't exist; `classify-and-create-surfaces` now writes it on upsert
- **Close child job rows** — child jobs were created but never updated, leaving them stuck at `status: running` forever on any failure; every task now calls `closeJob()` on both success and failure paths

## What was broken before this PR
- Searching for an unknown topic → job row created, Trigger.dev task never fired, topic stuck at `pending` forever
- `recompute-scores` always returned 0 surfaces because `surfaces.topic_id` didn't exist
- `SELECT * FROM jobs WHERE status = 'failed'` showed nothing useful even when the pipeline was broken

## Test plan
- [ ] Trigger an enrich request for a new topic slug, confirm Trigger.dev run appears in dashboard
- [ ] Confirm `jobs` row progresses through stages in Supabase (queued → finding_creators → ... → ready)
- [ ] Simulate a task failure, confirm child `jobs` row reaches `status: failed` with error message populated
- [ ] Confirm `topics.status` transitions from `pending` → `active` on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)